### PR TITLE
Add GitHub Actions to the repository

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: 1.20
+          go-version: 1.21
 
       - name: Verify Go installation
         run: go version


### PR DESCRIPTION
This PR adds continuous integration (CI) using GitHub Actions, including:
          
- Checkout code
- Set up Go environment
- Cache Go modules
- Install dependencies
- Run tests
- Generate and upload test coverage report

The workflow triggers on push and pull request events, except for branches with 'docbook' in the name. It can also be triggered manually.

Assignee: @andrii-yeremenko