### PR TITLE
Add manifest generation to CI github action.

### DIFF
--- a/operator/Taskfile.yaml
+++ b/operator/Taskfile.yaml
@@ -9,9 +9,6 @@ vars:
   CONTROLLER_GEN: "{{.LOCALBIN}}/controller-gen"
   KUSTOMIZE: "{{.LOCALBIN}}/kustomize"
 
-  KUSTOMIZE_VERSION: "v5.4.2"
-  CONTROLLER_TOOLS_VERSION: "v0.15.0"
-
   IGNORE_NOT_FOUND: "false"
 
 tasks:


### PR DESCRIPTION
This pull request introduces automatic Custom Resource Definitions (CRD) manifest generation as part of the continuous integration pipeline. The update enhances the GitHub Actions workflow by including the manifest generation step to ensure that the CRD manifests are always up-to-date and generated during the testing phase.

**Related Issues:**
Implements a CI check related to #9: K**ubernetes Operator for Managing News Feeds with CRD and Webhooks**
and #10 **Add HotNews CRD for Enhanced News Aggregation and Management**

**Assignee**: @andrii-yeremenko 
Please review and provide feedback.